### PR TITLE
fix(nix-enraged): version attribute missing

### DIFF
--- a/pkgs/nix-enraged/default.nix
+++ b/pkgs/nix-enraged/default.nix
@@ -83,4 +83,5 @@ in drv // {
     inherit nix';
   };
   inherit (nix') dev;
+  inherit (nix') version;
 }


### PR DESCRIPTION
fixes the error:

```
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/h2bn031b0fj0ymv9v7bv5rcdjx58y2l9-source/pkgs/stdenv/generic/make-derivation.nix:468:13

       … while evaluating attribute 'buildInputs' of derivation 'nix-shell'
         at /nix/store/h2bn031b0fj0ymv9v7bv5rcdjx58y2l9-source/pkgs/stdenv/generic/make-derivation.nix:523:13:
          522|             depsHostHost = elemAt (elemAt dependencies 1) 0;
          523|             buildInputs = elemAt (elemAt dependencies 1) 1;
             |             ^
          524|             depsTargetTarget = elemAt (elemAt dependencies 2) 0;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'version' missing
       at /nix/store/sdf4brgs3vmbbvsvwdskp0s7in72xgaa-source/src/default.nix:23:28:
           22|     # pinned because nix-copy-closure hangs if ControlPath provided for SSH: https://github.com/NixOS/nix/issues/8480
           23|     (if lib.versionAtLeast nix.version "2.16" then nix else nixVersions.nix_2_16)
             |                            ^
           24|     coreutils
```